### PR TITLE
Bumping the version to 1.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ dependencies {
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
-	modCompileOnly modLocalRuntime("eu.pb4:polymer-common:0.4.0-pre.2+1.19.4-rc2")
-	modCompileOnly modLocalRuntime("eu.pb4:placeholder-api:2.0.0-rc.1+1.19.3")
+	modCompileOnly modLocalRuntime("eu.pb4:polymer-common:0.5.0+1.20")
+	modCompileOnly modLocalRuntime("eu.pb4:placeholder-api:2.1.1+1.20")
 
 	modCompileOnly modLocalRuntime("org.openjdk.jol:jol-core:0.10")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,14 @@ org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-minecraft_version=1.19.4-rc2
-yarn_mappings=1.19.4-rc2+build.1
-loader_version=0.14.14
+minecraft_version=1.20
+yarn_mappings=1.20+build.1
+loader_version=0.14.21
 
-fabric_version=0.75.3+1.19.4
-
-
+fabric_version=0.83.0+1.20
 
 # Mod Properties
-	mod_version = 0.2.2+1.19.4
+	mod_version = 0.2.2+1.20
 	maven_group = eu.pb4
 	archives_base_name = mapcanvas
 

--- a/src/testmod/java/eu/pb4/mapcanvas/testmod/advancedgui/RaycastRenderer.java
+++ b/src/testmod/java/eu/pb4/mapcanvas/testmod/advancedgui/RaycastRenderer.java
@@ -67,7 +67,7 @@ public class RaycastRenderer implements ActiveRenderer {
 
         var pos = new Vec3d(this.entity.getX(), this.entity.getY() + this.entity.getStandingEyeHeight(), this.entity.getZ());
 
-        var world =  this.entity.world;
+        var world =  this.entity.getWorld();
         for (var x = 0; x < width; x++) {
             float yawAngle = (float) -Math.toRadians(yaw + (x - halfWidth) / 4 * pixelSize);
             float yawCos = MathHelper.cos(yawAngle);
@@ -104,7 +104,7 @@ public class RaycastRenderer implements ActiveRenderer {
                 int pY = y * pixelSize;
 
                 if (cast != null) {
-                    var state = this.entity.world.getBlockState(cast.getBlockPos());
+                    var state = this.entity.getWorld().getBlockState(cast.getBlockPos());
 
                     if (state.getBlock() instanceof PillarBlock) {
                         state = switch (state.get(PillarBlock.AXIS)) {
@@ -126,7 +126,7 @@ public class RaycastRenderer implements ActiveRenderer {
                         };
                     }
 
-                    var mapColor = state.getMapColor(this.entity.world, cast.getBlockPos());
+                    var mapColor = state.getMapColor(this.entity.getWorld(), cast.getBlockPos());
                     if (mapColor == MapColor.CLEAR) {
                         mapColor = MapColor.WHITE_GRAY;
                     }


### PR DESCRIPTION
## What this commit does
- Changes all dependencies to use 1.20
- changes all instances of entity.world to entity.getWorld() See why in [this article](https://fabricmc.net/2023/05/25/120.html) by Fabric team

Also, if you will merge it, please update the maven with this new version