### PR TITLE
Fix incorrect argument in IconContainer#createIcon

### DIFF
--- a/src/main/java/eu/pb4/mapcanvas/api/core/IconContainer.java
+++ b/src/main/java/eu/pb4/mapcanvas/api/core/IconContainer.java
@@ -18,7 +18,7 @@ public interface IconContainer {
     }
 
     default CanvasIcon createIcon(RegistryEntry<MapDecorationType> type, int x, int y, byte rotation, @Nullable Text text) {
-        return this.createIcon(type, true, x, y,  (byte) 0, text);
+        return this.createIcon(type, true, x, y, rotation, text);
     }
 
     Collection<CanvasIcon> getIcons();


### PR DESCRIPTION
Fixes a bug where an icon will always be created with a 0 rotation even when a specified rotation is given.