### PR TITLE
Implement `DrawableCanvas.fill`

### DIFF
--- a/src/main/java/eu/pb4/mapcanvas/api/core/CanvasImage.java
+++ b/src/main/java/eu/pb4/mapcanvas/api/core/CanvasImage.java
@@ -128,6 +128,11 @@ public final class CanvasImage implements DrawableCanvas, IconContainer {
     }
 
     @Override
+    public void fillRaw(byte color) {
+        Arrays.fill(this.data, color);
+    }
+
+    @Override
     public int getHeight() {
         return this.height;
     }

--- a/src/main/java/eu/pb4/mapcanvas/api/core/DrawableCanvas.java
+++ b/src/main/java/eu/pb4/mapcanvas/api/core/DrawableCanvas.java
@@ -31,8 +31,10 @@ public interface DrawableCanvas {
     void setRaw(int x, int y, byte color);
 
     default void fillRaw(byte color) {
-        for (int x = 0; x < this.getWidth(); x++) {
-            for (int y = 0; y < this.getHeight(); y++) {
+        int width = this.getWidth();
+        int height = this.getHeight();
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
                 this.setRaw(x, y, color);
             }
         }

--- a/src/main/java/eu/pb4/mapcanvas/api/core/DrawableCanvas.java
+++ b/src/main/java/eu/pb4/mapcanvas/api/core/DrawableCanvas.java
@@ -18,9 +18,25 @@ public interface DrawableCanvas {
         return CanvasColor.BY_RENDER_COLOR[Byte.toUnsignedInt(this.getRaw(x, y))];
     }
 
+    default void fill(MapColor color, MapColor.Brightness brightness) {
+        this.fillRaw(color.getRenderColorByte(brightness));
+    }
+
+    default void fill(CanvasColor color) {
+        this.fillRaw(color.renderColor);
+    }
+
     byte getRaw(int x, int y);
 
     void setRaw(int x, int y, byte color);
+
+    default void fillRaw(byte color) {
+        for (int x = 0; x < this.getWidth(); x++) {
+            for (int y = 0; y < this.getHeight(); y++) {
+                this.setRaw(x, y, color);
+            }
+        }
+    }
 
     int getHeight();
 

--- a/src/main/java/eu/pb4/mapcanvas/api/utils/CanvasUtils.java
+++ b/src/main/java/eu/pb4/mapcanvas/api/utils/CanvasUtils.java
@@ -26,15 +26,7 @@ public final class CanvasUtils {
     }
 
     public static void clear(DrawableCanvas canvas, CanvasColor color) {
-        final int width = canvas.getWidth();
-        final int height = canvas.getHeight();
-        final byte renderColor = color.getRenderColor();
-
-        for (int x = 0; x < width; x++) {
-            for (int y = 0; y < height; y++) {
-                canvas.setRaw(x, y, renderColor);
-            }
-        }
+        canvas.fill(color);
     }
 
     public static void fill(DrawableCanvas canvas, int x1, int y1, int x2, int y2, CanvasColor color) {

--- a/src/main/java/eu/pb4/mapcanvas/impl/MultiMapCanvasImpl.java
+++ b/src/main/java/eu/pb4/mapcanvas/impl/MultiMapCanvasImpl.java
@@ -114,6 +114,13 @@ public final class MultiMapCanvasImpl implements CombinedPlayerCanvas {
     }
 
     @Override
+    public void fillRaw(byte color) {
+        for (MapCanvasPart part : this.parts) {
+            part.fillRaw(color);
+        }
+    }
+
+    @Override
     public int getHeight() {
         return this.height * CanvasUtils.MAP_DATA_SIZE;
     }

--- a/src/main/java/eu/pb4/mapcanvas/impl/view/Matrix3x2fTransformedView.java
+++ b/src/main/java/eu/pb4/mapcanvas/impl/view/Matrix3x2fTransformedView.java
@@ -1,8 +1,6 @@
 package eu.pb4.mapcanvas.impl.view;
 
-import eu.pb4.mapcanvas.api.core.CanvasColor;
 import eu.pb4.mapcanvas.api.core.DrawableCanvas;
-import org.joml.Matrix3x2f;
 import org.joml.Matrix3x2fc;
 import org.joml.Vector2f;
 
@@ -27,6 +25,11 @@ public record Matrix3x2fTransformedView(DrawableCanvas source, int width, int he
         }
 
         this.source.setRaw((int) this.ownVec.x, (int) this.ownVec.y, color);
+    }
+
+    @Override
+    public void fillRaw(byte color) {
+        this.source.fillRaw(color);
     }
 
     @Override

--- a/src/main/java/eu/pb4/mapcanvas/impl/view/RepeatedView.java
+++ b/src/main/java/eu/pb4/mapcanvas/impl/view/RepeatedView.java
@@ -19,6 +19,11 @@ public record RepeatedView(DrawableCanvas source, int width, int height) impleme
     }
 
     @Override
+    public void fillRaw(byte color) {
+        this.source.fillRaw(color);
+    }
+
+    @Override
     public int getHeight() {
         return this.height;
     }

--- a/src/main/java/eu/pb4/mapcanvas/impl/view/Rotate90ClockwiseView.java
+++ b/src/main/java/eu/pb4/mapcanvas/impl/view/Rotate90ClockwiseView.java
@@ -14,6 +14,11 @@ public record Rotate90ClockwiseView(DrawableCanvas source) implements DrawableCa
     }
 
     @Override
+    public void fillRaw(byte color) {
+        this.source.fillRaw(color);
+    }
+
+    @Override
     public int getHeight() {
         return this.source.getWidth();
     }

--- a/src/main/java/eu/pb4/mapcanvas/impl/view/RotatedView.java
+++ b/src/main/java/eu/pb4/mapcanvas/impl/view/RotatedView.java
@@ -81,6 +81,11 @@ public class RotatedView implements DrawableCanvas {
     }
 
     @Override
+    public void fillRaw(byte color) {
+        this.source.fillRaw(color);
+    }
+
+    @Override
     public int getHeight() {
         return this.width;
     }

--- a/src/main/java/eu/pb4/mapcanvas/impl/view/ShiftedView.java
+++ b/src/main/java/eu/pb4/mapcanvas/impl/view/ShiftedView.java
@@ -14,6 +14,11 @@ public record ShiftedView(DrawableCanvas source, int width, int height) implemen
     }
 
     @Override
+    public void fillRaw(byte color) {
+        this.source.fillRaw(color);
+    }
+
+    @Override
     public int getHeight() {
         return this.height;
     }

--- a/src/main/java/eu/pb4/mapcanvas/impl/view/SubView.java
+++ b/src/main/java/eu/pb4/mapcanvas/impl/view/SubView.java
@@ -20,6 +20,11 @@ public record SubView(DrawableCanvas source, int x1, int y1, int width, int heig
     }
 
     @Override
+    public void fillRaw(byte color) {
+        this.source.fillRaw(color);
+    }
+
+    @Override
     public int getHeight() {
         return this.height;
     }

--- a/src/main/java/eu/pb4/mapcanvas/impl/view/TransformedView.java
+++ b/src/main/java/eu/pb4/mapcanvas/impl/view/TransformedView.java
@@ -17,6 +17,11 @@ public record TransformedView(DrawableCanvas source, ViewUtils.Transformer trans
     }
 
     @Override
+    public void fillRaw(byte color) {
+        this.source.fillRaw(color);
+    }
+
+    @Override
     public int getHeight() {
         return this.source.getHeight();
     }

--- a/src/main/java/eu/pb4/mapcanvas/impl/view/XFlipView.java
+++ b/src/main/java/eu/pb4/mapcanvas/impl/view/XFlipView.java
@@ -14,6 +14,11 @@ public record XFlipView(DrawableCanvas source) implements DrawableCanvas {
     }
 
     @Override
+    public void fillRaw(byte color) {
+        this.source.fillRaw(color);
+    }
+
+    @Override
     public int getHeight() {
         return this.source.getHeight();
     }

--- a/src/main/java/eu/pb4/mapcanvas/impl/view/YFlipView.java
+++ b/src/main/java/eu/pb4/mapcanvas/impl/view/YFlipView.java
@@ -14,6 +14,11 @@ public record YFlipView(DrawableCanvas source) implements DrawableCanvas {
     }
 
     @Override
+    public void fillRaw(byte color) {
+        this.source.fillRaw(color);
+    }
+
+    @Override
     public int getHeight() {
         return this.source.getHeight();
     }

--- a/src/main/java/eu/pb4/mapcanvas/impl/view/YSkewedView.java
+++ b/src/main/java/eu/pb4/mapcanvas/impl/view/YSkewedView.java
@@ -14,6 +14,11 @@ public record YSkewedView(DrawableCanvas source, double skewPerPixel) implements
     }
 
     @Override
+    public void fillRaw(byte color) {
+        this.source.fillRaw(color);
+    }
+
+    @Override
     public int getHeight() {
         return this.source.getHeight();
     }


### PR DESCRIPTION
This adds a `fill` method to the `DrawableCanvas` interface which fills the entire canvas with a single colour.
This could be previously done with `CanvasUtils.clear`, which sets each pixel with `setRaw`, for some `DrawableCanvas` implementations this can be optimised, especially the transformed views. The `fillRaw` method now lets canvases implement their own fill methods. 

I was unsure able the implementation for `BaseMapCanvas`, as how to mark it dirty - whether it should mark the entire map as dirty or just use the naive method and check each pixel.