### PR TITLE
Fix concurrent modification on SingleMapCanvas.destroy()

### DIFF
--- a/src/main/java/eu/pb4/mapcanvas/impl/SingleMapCanvas.java
+++ b/src/main/java/eu/pb4/mapcanvas/impl/SingleMapCanvas.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.ArrayList;
 
 public final class SingleMapCanvas extends AbstractPlayerMapCanvas {
     private final Set<ServerPlayNetworkHandler> players = Collections.synchronizedSet(new HashSet<>());
@@ -21,7 +22,7 @@ public final class SingleMapCanvas extends AbstractPlayerMapCanvas {
 
     @Override
     public void destroy() {
-        for (var player : this.players) {
+        for (var player : new ArrayList<>(this.players)) {
             this.removePlayer(player);
         }
         super.destroy();


### PR DESCRIPTION
If there is more than one player added to a SingleMapCanvas, a ConcurrentModificationException is thrown when the canvas is destroyed.
This PR iterates over a copy of the players collection for removal of the players, like in MultiMapCanvasImpl.

Closes #8 